### PR TITLE
グラフの不自然な動きの修正

### DIFF
--- a/src/app/api/population/route.ts
+++ b/src/app/api/population/route.ts
@@ -1,4 +1,4 @@
-import { PopulationResponse } from '@/app/types/types'
+import { PopulationResponse, PopulationResponseNoPrefCode } from '@/app/types/types'
 import { type NextRequest } from 'next/server'
 
 export async function GET(request: NextRequest) {
@@ -26,9 +26,18 @@ export async function GET(request: NextRequest) {
       },
     )
   }
+  
+  const data: PopulationResponseNoPrefCode = await response.json()
 
-  const data: PopulationResponse = await response.json()
-  return new Response(JSON.stringify(data), {
+  // prefCodeをレスポンスに付加
+  const dataWithPrefCode: PopulationResponse = {
+    message: data.message,
+    result: {
+      ...data.result,
+      prefCode: Number(query),
+    },
+  }
+  return new Response(JSON.stringify(dataWithPrefCode), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   })

--- a/src/app/components/PopulationGraph.tsx
+++ b/src/app/components/PopulationGraph.tsx
@@ -106,9 +106,9 @@ const PopulationGraph = ({
     } = {}
 
     // 取得した各都道府県の人口データをループ
-    populationData.forEach((prefPop, index) => {
+    populationData.forEach((prefPop) => {
       // APIレスポンスとチェックされたコードの順番は対応している
-      const prefCode = checkedCode[index]
+      const prefCode = prefPop.prefCode
       const prefName = prefMap.get(prefCode)
       if (!prefName) return
 
@@ -128,7 +128,7 @@ const PopulationGraph = ({
     return Object.values(formattedData).sort(
       (a, b) => (a.year as number) - (b.year as number),
     )
-  }, [populationData, checkedCode, prefectures, graphOption])
+  }, [populationData, prefectures, graphOption])
 
   return (
     <>

--- a/src/app/types/types.ts
+++ b/src/app/types/types.ts
@@ -12,6 +12,7 @@ export type PrefectureResponse = {
 
 // 人口構成データ
 export type Population = {
+  prefCode: number
   boundaryYear: number
   data: {
     label: string
@@ -27,6 +28,14 @@ export type Population = {
 export type PopulationResponse = {
   message: string
   result: Population
+}
+
+// 人口構成データ（都道府県コード追加前）
+export type PopulationNoPrefCode = Omit<Population, 'prefCode'>
+// 人口構成APIレスポンス（resultに都道府県コード追加前のデータ）
+export type PopulationResponseNoPrefCode = {
+  message: string
+  result: PopulationNoPrefCode
 }
 
 export type GraphOption = '総人口' | '年少人口' | '生産年齢人口' | '老年人口'


### PR DESCRIPTION
特定の状況下で都道府県の選択を解除すると、残ったグラフのラインが削除されたラインのあった場所に一瞬行こうとする不自然な動作がありました。
原因はラインのデータをインデックスで管理していたことです。レスポンスに都道府県コードを付加することで絶対座標での管理が可能になり、不自然な動作がなくなりました。